### PR TITLE
:hammer: 調整 forward header strategy

### DIFF
--- a/spring/src/main/resources/application.yaml
+++ b/spring/src/main/resources/application.yaml
@@ -33,3 +33,6 @@ springdoc:
     doc-expansion: none
     operations-sorter: alpha
     tags-sorter: alpha
+
+server:
+  forward-headers-strategy: native


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 現在 OAuth2.0 流程在轉址時，後端同一網址會「轉兩次」，先轉到 `http://` 再轉到 `https://`，解決這問題，後端需要讀取從 nginx 傳過來的 `X-Forwarded-Proto HTTP Header`，這樣在做轉址時的 Protocol 才會正確。

## Changes made:
- `application.yml`
## Test Scope / Change impact:
- none
## Issue
- resolved #94 