### PR TITLE
feature: room player readay and cancel

### DIFF
--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/repositories/RoomRepository.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/repositories/RoomRepository.kt
@@ -9,6 +9,6 @@ interface RoomRepository {
     fun createRoom(room: Room): Room
     fun findById(roomId: Room.Id): Room?
     fun existsByHostId(hostId: User.Id): Boolean
-    fun joinRoom(room: Room): Room
+    fun update(room: Room): Room
     fun findByStatus(status: Room.Status, page: Pagination<Any>): Pagination<Room>
 }

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/ChangePlayerReadinessUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/ChangePlayerReadinessUsecase.kt
@@ -12,7 +12,7 @@ class ChangePlayerReadinessUsecase(
     fun execute(request: Request) {
         with(request) {
             val room = roomRepository.findById(roomId.toRoomId())
-                ?: throw notFound(Room::class).shortMessage()
+                ?: throw notFound(Room::class).message()
             room.changePlayerReadiness(userId.toRoomPlayerId(), readiness)
             roomRepository.update(room)
         }

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/ChangePlayerReadinessUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/ChangePlayerReadinessUsecase.kt
@@ -1,0 +1,36 @@
+package tw.waterballsa.gaas.application.usecases
+
+import tw.waterballsa.gaas.application.repositories.RoomRepository
+import tw.waterballsa.gaas.domain.Room
+import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
+import javax.inject.Named
+
+@Named
+class ChangePlayerReadinessUsecase(
+    private val roomRepository: RoomRepository
+) {
+    fun execute(request: Request) {
+        with(request) {
+            val room = roomRepository.findById(roomId.toRoomId())
+                ?: throw notFound(Room::class).shortMessage()
+            room.changePlayerReadiness(userId.toRoomPlayerId(), readiness)
+            roomRepository.update(room)
+        }
+    }
+
+    private fun String.toRoomId(): Room.Id = Room.Id(this)
+
+    private fun String.toRoomPlayerId(): Room.Player.Id = Room.Player.Id(this)
+
+    data class Request(
+        val roomId: String,
+        val userId: String,
+        val readiness: Boolean
+    ) {
+        companion object {
+            fun ready(roomId: String, userId: String): Request = Request(roomId, userId, true)
+
+            fun cancelReady(roomId: String, userId: String): Request = Request(roomId, userId, false)
+        }
+    }
+}

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/JoinRoomUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/JoinRoomUsecase.kt
@@ -45,7 +45,7 @@ class JoinRoomUsecase(
     private fun Room.joinPlayer(userId: String): Room {
         val player = findPlayerByUserId(User.Id(userId))
         addPlayer(player)
-        return roomRepository.joinRoom(this)
+        return roomRepository.update(this)
     }
 
     private fun findPlayerByUserId(userId: User.Id) =

--- a/domain/src/main/kotlin/tw/waterballsa/gaas/domain/Room.kt
+++ b/domain/src/main/kotlin/tw/waterballsa/gaas/domain/Room.kt
@@ -1,6 +1,7 @@
 package tw.waterballsa.gaas.domain
 
 import tw.waterballsa.gaas.domain.Room.Status.WAITING
+import tw.waterballsa.gaas.exceptions.PlatformException
 
 class Room(
     var roomId: Id? = null,
@@ -26,6 +27,17 @@ class Room(
 
     fun isFull(): Boolean = players.size >= maxPlayers
 
+    fun changePlayerReadiness(playerId: Player.Id, readiness: Boolean) {
+        val player = findPlayer(playerId) ?: throw PlatformException("Player not joined")
+        if (readiness) {
+            player.ready()
+        } else {
+            player.cancelReady()
+        }
+    }
+
+    private fun findPlayer(playerId: Player.Id): Player? = players.find { it.id == playerId }
+
     @JvmInline
     value class Id(val value: String)
 
@@ -36,7 +48,19 @@ class Room(
     class Player(
         val id: Id,
         val nickname: String,
+        readiness: Boolean = false
     ) {
+        var readiness: Boolean = readiness
+            private set
+
+        fun ready() {
+            readiness = true
+        }
+
+        fun cancelReady() {
+            readiness = false
+        }
+
         @JvmInline
         value class Id(val value: String)
     }

--- a/domain/src/main/kotlin/tw/waterballsa/gaas/exceptions/NotFoundException.kt
+++ b/domain/src/main/kotlin/tw/waterballsa/gaas/exceptions/NotFoundException.kt
@@ -10,6 +10,10 @@ class NotFoundException private constructor(message: String) : PlatformException
 
     private constructor(id: Any, resourceName: String) : this(id, "id", resourceName)
 
+    private constructor(message: String, resourceName: String): this(
+        "Resource (${resourceName.capitalize()}) not found (${resourceName.capitalize()} = $message)."
+    )
+
     companion object {
         fun <T : Any> notFound(resourceType: KClass<T>): NotFoundExceptionBuilder = notFound(resourceType.simpleName!!)
 
@@ -23,8 +27,9 @@ class NotFoundException private constructor(message: String) : PlatformException
 
             fun message(messageObj: Any): NotFoundException = message(messageObj.toString())
 
-            fun message(message: String): NotFoundException =
-                NotFoundException("Resource ($resourceName) not found ($resourceName = $message).")
+            fun message(message: String): NotFoundException = NotFoundException(message, resourceName)
+
+            fun shortMessage(): NotFoundException = NotFoundException("${resourceName.capitalize()} not found")
         }
     }
 }

--- a/domain/src/main/kotlin/tw/waterballsa/gaas/exceptions/NotFoundException.kt
+++ b/domain/src/main/kotlin/tw/waterballsa/gaas/exceptions/NotFoundException.kt
@@ -21,7 +21,7 @@ class NotFoundException private constructor(message: String) : PlatformException
 
             fun id(id: Any): NotFoundException = NotFoundException(id, resourceName)
 
-            fun shortMessage(): NotFoundException = NotFoundException("${resourceName.capitalize()} not found")
+            fun message(): NotFoundException = NotFoundException("${resourceName.capitalize()} not found")
         }
     }
 }

--- a/domain/src/main/kotlin/tw/waterballsa/gaas/exceptions/NotFoundException.kt
+++ b/domain/src/main/kotlin/tw/waterballsa/gaas/exceptions/NotFoundException.kt
@@ -10,10 +10,6 @@ class NotFoundException private constructor(message: String) : PlatformException
 
     private constructor(id: Any, resourceName: String) : this(id, "id", resourceName)
 
-    private constructor(message: String, resourceName: String): this(
-        "Resource (${resourceName.capitalize()}) not found (${resourceName.capitalize()} = $message)."
-    )
-
     companion object {
         fun <T : Any> notFound(resourceType: KClass<T>): NotFoundExceptionBuilder = notFound(resourceType.simpleName!!)
 
@@ -24,10 +20,6 @@ class NotFoundException private constructor(message: String) : PlatformException
                 NotFoundException(identifierName, resourceName)
 
             fun id(id: Any): NotFoundException = NotFoundException(id, resourceName)
-
-            fun message(messageObj: Any): NotFoundException = message(messageObj.toString())
-
-            fun message(message: String): NotFoundException = NotFoundException(message, resourceName)
 
             fun shortMessage(): NotFoundException = NotFoundException("${resourceName.capitalize()} not found")
         }

--- a/spring/src/main/kotlin/tw/waterballsa/gaas/spring/aspects/PlatformExceptionHandler.kt
+++ b/spring/src/main/kotlin/tw/waterballsa/gaas/spring/aspects/PlatformExceptionHandler.kt
@@ -1,21 +1,21 @@
 package tw.waterballsa.gaas.spring.aspects
 
 import org.springframework.http.HttpStatus.*
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import tw.waterballsa.gaas.exceptions.NotFoundException
 import tw.waterballsa.gaas.exceptions.PlatformException
+import tw.waterballsa.gaas.spring.controllers.viewmodel.PlatformViewModel
 
 @RestControllerAdvice
 class PlatformExceptionHandler {
     @ResponseStatus(NOT_FOUND)
     @ExceptionHandler(NotFoundException::class)
-    fun notFound(exception: NotFoundException): String = exception.message!!
+    fun notFound(exception: NotFoundException): PlatformViewModel = PlatformViewModel(exception.message!!)
 
     @ResponseStatus(BAD_REQUEST)
     @ExceptionHandler(PlatformException::class)
-    fun badRequest(exception: PlatformException): Map<String, String> = mapOf("message" to (exception.message ?: ""))
+    fun badRequest(exception: PlatformException): PlatformViewModel = PlatformViewModel(exception.message!!)
 
 }

--- a/spring/src/main/kotlin/tw/waterballsa/gaas/spring/controllers/viewmodel/PlatformViewModel.kt
+++ b/spring/src/main/kotlin/tw/waterballsa/gaas/spring/controllers/viewmodel/PlatformViewModel.kt
@@ -1,0 +1,9 @@
+package tw.waterballsa.gaas.spring.controllers.viewmodel
+
+data class PlatformViewModel(
+    val message: String
+) {
+    companion object {
+        fun success(): PlatformViewModel = PlatformViewModel("success")
+    }
+}

--- a/spring/src/main/kotlin/tw/waterballsa/gaas/spring/repositories/SpringRoomRepositoryImpl.kt
+++ b/spring/src/main/kotlin/tw/waterballsa/gaas/spring/repositories/SpringRoomRepositoryImpl.kt
@@ -6,11 +6,9 @@ import org.springframework.stereotype.Component
 import tw.waterballsa.gaas.application.model.Pagination
 import tw.waterballsa.gaas.application.repositories.GameRegistrationRepository
 import tw.waterballsa.gaas.application.repositories.RoomRepository
-import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.GameRegistration
 import tw.waterballsa.gaas.domain.Room
 import tw.waterballsa.gaas.domain.Room.Id
-import tw.waterballsa.gaas.domain.Room.Player
 import tw.waterballsa.gaas.domain.User
 import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import tw.waterballsa.gaas.spring.extensions.mapOrNull
@@ -22,7 +20,6 @@ import tw.waterballsa.gaas.spring.repositories.data.RoomData.Companion.toData
 class SpringRoomRepository(
     private val roomDAO: RoomDAO,
     private val gameRegistrationRepository: GameRegistrationRepository,
-    private val userRepository: UserRepository
 ) : RoomRepository {
     override fun createRoom(room: Room): Room = roomDAO.save(room.toData()).toDomain()
 
@@ -34,7 +31,7 @@ class SpringRoomRepository(
 
     override fun existsByHostId(hostId: User.Id): Boolean = roomDAO.existsByHostId(hostId.value)
 
-    override fun joinRoom(room: Room): Room = roomDAO.save(room.toData()).toDomain(room.game, room.host, room.players)
+    override fun update(room: Room): Room = roomDAO.save(room.toData()).toDomain(room.game, room.host, room.players)
 
     override fun findByStatus(status: Room.Status, page: Pagination<Any>): Pagination<Room> {
         return roomDAO.findByStatus(status, page.toPageable())
@@ -42,38 +39,24 @@ class SpringRoomRepository(
         .toPagination()
     }
 
-    private fun RoomData.toDomain(): Room =
-        Room(
+    private fun RoomData.toDomain(): Room {
+        return Room(
             roomId = Id(id!!),
             game = GameRegistration.Id(gameRegistrationId).toGameRegistration(),
-            host = User.Id(hostId).toRoomPlayer(),
-            players = userRepository.findRoomPlayers(playerIds),
+            host = players.find { it.playerId == hostId }!!.toDomain(),
+            players = players.map { it.toDomain() }.toMutableList(),
             maxPlayers = maxPlayers,
             minPlayers = minPlayers,
             name = name,
             password = password,
         )
+    }
 
     private fun GameRegistration.Id.toGameRegistration(): GameRegistration =
         gameRegistrationRepository.findById(this)
             ?: throw notFound(GameRegistration::class).id(value)
 
-    private fun User.Id.toRoomPlayer(): Player =
-        userRepository.findById(this)
-            ?.toRoomPlayer()
-            ?: throw notFound(User::class).id(value)
 }
-
-private fun UserRepository.findRoomPlayers(playerIds: Collection<String>): MutableList<Player> =
-    findAllById(playerIds.map(User::Id))
-        .map { user -> user.toRoomPlayer() }
-        .toMutableList()
-
-private fun User.toRoomPlayer(): Player =
-    Player(
-        id = Player.Id(id!!.value),
-        nickname = nickname
-    )
 
 private fun Pagination<Any>.toPageable() = PageRequest.of(page, offset)
 

--- a/spring/src/main/kotlin/tw/waterballsa/gaas/spring/repositories/data/RoomData.kt
+++ b/spring/src/main/kotlin/tw/waterballsa/gaas/spring/repositories/data/RoomData.kt
@@ -53,9 +53,9 @@ class RoomData(
         )
 
     class PlayerData(
-        var playerId: String,
-        var nickname: String,
-        var readiness: Boolean
+        val playerId: String,
+        val nickname: String,
+        val readiness: Boolean
     ) {
         companion object {
             fun Room.Player.toData(): PlayerData = PlayerData(id.value, nickname, readiness)

--- a/spring/src/main/kotlin/tw/waterballsa/gaas/spring/repositories/data/RoomData.kt
+++ b/spring/src/main/kotlin/tw/waterballsa/gaas/spring/repositories/data/RoomData.kt
@@ -5,6 +5,7 @@ import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import tw.waterballsa.gaas.domain.GameRegistration
 import tw.waterballsa.gaas.domain.Room
+import tw.waterballsa.gaas.spring.repositories.data.RoomData.PlayerData.Companion.toData
 
 @Document
 class RoomData(
@@ -15,7 +16,7 @@ class RoomData(
     var gameRegistrationId: String,
     @Indexed(unique = true)
     var hostId: String,
-    var playerIds: List<String>,
+    var players: List<PlayerData>,
     var maxPlayers: Int,
     var minPlayers: Int,
     var isLocked: Boolean,
@@ -27,7 +28,7 @@ class RoomData(
                 id = roomId?.value,
                 gameRegistrationId = game.id!!.value,
                 hostId = host.id.value,
-                playerIds = players.map { it.id.value },
+                players = players.map { it.toData() },
                 maxPlayers = maxPlayers,
                 minPlayers = minPlayers,
                 name = name,
@@ -50,4 +51,18 @@ class RoomData(
             status = status!!,
             password = password
         )
+
+    class PlayerData(
+        var playerId: String,
+        var nickname: String,
+        var readiness: Boolean
+    ) {
+        companion object {
+            fun Room.Player.toData(): PlayerData = PlayerData(id.value, nickname, readiness)
+        }
+
+        fun toDomain(): Room.Player =
+            Room.Player(Room.Player.Id(playerId), nickname, readiness)
+    }
+
 }

--- a/spring/src/test/kotlin/tw/waterballsa/gaas/spring/it/controllers/RoomControllerTest.kt
+++ b/spring/src/test/kotlin/tw/waterballsa/gaas/spring/it/controllers/RoomControllerTest.kt
@@ -22,7 +22,6 @@ import tw.waterballsa.gaas.domain.GameRegistration
 import tw.waterballsa.gaas.domain.Room
 import tw.waterballsa.gaas.domain.Room.Player
 import tw.waterballsa.gaas.domain.User
-import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import tw.waterballsa.gaas.spring.it.AbstractSpringBootTest
 import tw.waterballsa.gaas.spring.models.TestCreateRoomRequest
 import tw.waterballsa.gaas.spring.models.TestGetRoomsRequest

--- a/spring/src/test/kotlin/tw/waterballsa/gaas/spring/it/controllers/RoomControllerTest.kt
+++ b/spring/src/test/kotlin/tw/waterballsa/gaas/spring/it/controllers/RoomControllerTest.kt
@@ -319,7 +319,7 @@ class RoomControllerTest @Autowired constructor(
 
     private fun<T: Any> ResultActions.thenShouldBeNotFound(resourceType: KClass<T>) {
         andExpect(status().isNotFound)
-            .andExpect(jsonPath("$.message").value(notFound(resourceType).shortMessage().message))
+            .andExpect(jsonPath("$.message").value("${resourceType.simpleName} not found"))
     }
     private fun notExistsRoom(): Room{
         val notExistRoomHost = Player(Player.Id(""), "")


### PR DESCRIPTION
## Why need this change? / Root cause: 
- As a user in the room, I want to ready or cancel ready.
## Changes made:
- Room Player add readiness field.
- Refactor RoomRepository's joinRoom function name to update for reuse.
- Refactor JoinRoomViewModel name to RoomActionViewModel for reuse.
- Add ChangePlayerReadinessUsecase for feature.
## Test Scope / Change impact:
- RoomController
## Issue
- resolves https://github.com/Game-as-a-Service/Lobby-Platform-Service/issues/103
- resolves https://github.com/Game-as-a-Service/Lobby-Platform-Service/issues/104