### PR TITLE
👷 fix(ci): use mvn verify

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -35,9 +35,9 @@ jobs:
       # Dump GitHub Context
       - name: Dump GitHub Context
         run: |
-          echo "```" >> $GITHUB_STEP_SUMMARY
-          echo "${{ toJson(github) }}" >> $GITHUB_STEP_SUMMARY
-          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo '${{ toJSON(github) }}' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       # Publish Artifact
       - name: Upload Artifact

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,32 +12,31 @@ permissions:
   contents: read    # This is required for actions/checkout
 
 jobs:
-  
-  maven-package:
-    name: Maven Package
+  build:
+    name: Build on GitHub
     runs-on: ubuntu-latest
-    
+
     steps:
       # Checkout the repo
       - name: git checkout
         uses: actions/checkout@v3
 
-      # Setup JDK / Maven
+      # Setup JDK 17
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'corretto'
 
-      # Package and Test with Maven
-      - name: Package and Test with Maven
-        run: mvn -B package -DJAR_FILENAME=${{ env.JAR_FILENAME }}
+      # Maven Verify
+      - name: Maven Verify
+        run: mvn -B verify -DJAR_FILENAME=${{ env.JAR_FILENAME }}
       
       # Dump GitHub Context
       - name: Dump GitHub Context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
+        run: echo -e "```\n$GITHUB_CONTEXT\n```" >> $GITHUB_STEP_SUMMARY
 
       # Publish Artifact
       - name: Upload Artifact
@@ -52,7 +51,7 @@ jobs:
   docker-push:
     name: Docker Push
     runs-on: ubuntu-latest
-    needs: maven-package
+    needs: build
     environment: production
     if: github.event_name == 'push' && github.ref_name == 'main'
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -34,9 +34,10 @@ jobs:
       
       # Dump GitHub Context
       - name: Dump GitHub Context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo -e "```\n$GITHUB_CONTEXT\n```" >> $GITHUB_STEP_SUMMARY
+        run: |
+          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo "${{ toJson(github) }}" >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY
 
       # Publish Artifact
       - name: Upload Artifact


### PR DESCRIPTION
## Why need this change? / Root cause: 
### Maven Lifecycle
1. clean
2. validate
3. compile
4. test
5. package
6. verify
7. install
8. site
9. deploy

Maven 的 Lifecycle 只要執行一個階段 i.e. (5) `mvn package`，前面的 (4) `test`, (3) `compile`, (2) `validate` and (1) `clean` 都會執行。

我們的 CI/CD 是執行 `mvn package`，而 lint 是綁在 `mvn verify`。

為了把 lint 包含在 CI/CD 裡，我們 CI/CD 的 maven 指令將更改成 `mvn verify`。

## Changes made:
- change maven command from `mvn package` to `mvn verify`
- enhance dumping GitHub Context format

## Test Scope / Change impact:
- CI/CD pipeline

## Issue
- 