### PR TITLE
fix: jwt subject is user identity

### DIFF
--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/repositories/UserRepository.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/repositories/UserRepository.kt
@@ -11,5 +11,6 @@ interface UserRepository {
     fun deleteAll()
     fun findAllById(ids: Collection<Id>): List<User>
     fun findByEmail(email: String): User?
+    fun findByIdentity(identity: String): User?
     fun update(user: User): User
 }

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/AbstractRoomUseCase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/AbstractRoomUseCase.kt
@@ -1,0 +1,16 @@
+package tw.waterballsa.gaas.application.usecases
+
+import tw.waterballsa.gaas.application.extension.toRoomPlayer
+import tw.waterballsa.gaas.application.repositories.UserRepository
+import tw.waterballsa.gaas.domain.Room
+import tw.waterballsa.gaas.domain.User
+import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
+
+abstract class AbstractRoomUseCase(
+    protected val userRepository: UserRepository,
+) {
+    fun findPlayerByIdentity(userIdentity: String): Room.Player =
+        userRepository.findByIdentity(userIdentity)
+            ?.toRoomPlayer()
+            ?: throw notFound(User::class).message()
+}

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/AbstractRoomUseCase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/AbstractRoomUseCase.kt
@@ -1,16 +1,29 @@
 package tw.waterballsa.gaas.application.usecases
 
 import tw.waterballsa.gaas.application.extension.toRoomPlayer
+import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
 import tw.waterballsa.gaas.domain.User
 import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 
 abstract class AbstractRoomUseCase(
+    protected val roomRepository: RoomRepository,
     protected val userRepository: UserRepository,
 ) {
-    fun findPlayerByIdentity(userIdentity: String): Room.Player =
+    protected fun findPlayerByIdentity(userIdentity: String): Room.Player =
         userRepository.findByIdentity(userIdentity)
             ?.toRoomPlayer()
             ?: throw notFound(User::class).message()
+
+    protected fun findRoomById(roomId: String, messageWithId: Boolean = true): Room {
+        val id = Room.Id(roomId)
+        val notFoundException = if (messageWithId) {
+            notFound(Room::class).id(id)
+        } else {
+            notFound(Room::class).message()
+        }
+        return roomRepository.findById(id)
+            ?: throw notFoundException
+    }
 }

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/ChangePlayerReadinessUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/ChangePlayerReadinessUsecase.kt
@@ -2,26 +2,21 @@ package tw.waterballsa.gaas.application.usecases
 
 import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
-import tw.waterballsa.gaas.domain.Room
-import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import javax.inject.Named
 
 @Named
 class ChangePlayerReadinessUsecase(
-    private val roomRepository: RoomRepository,
+    roomRepository: RoomRepository,
     userRepository: UserRepository,
-) : AbstractRoomUseCase(userRepository) {
+) : AbstractRoomUseCase(roomRepository, userRepository) {
     fun execute(request: Request) {
         with(request) {
-            val room = roomRepository.findById(roomId.toRoomId())
-                ?: throw notFound(Room::class).message()
+            val room = findRoomById(roomId, false)
             val player = findPlayerByIdentity(userIdentity)
             room.changePlayerReadiness(player.id, readiness)
             roomRepository.update(room)
         }
     }
-
-    private fun String.toRoomId(): Room.Id = Room.Id(this)
 
     data class Request(
         val roomId: String,

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/ChangePlayerReadinessUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/ChangePlayerReadinessUsecase.kt
@@ -17,7 +17,8 @@ class ChangePlayerReadinessUsecase(
         with(request) {
             val room = roomRepository.findById(roomId.toRoomId())
                 ?: throw notFound(Room::class).message()
-            val player = userRepository.findByIdentity(playerIdentity)?.toRoomPlayer()
+            val player = userRepository.findByIdentity(userIdentity)
+                ?.toRoomPlayer()
                 ?: throw notFound(User::class).message()
             room.changePlayerReadiness(player.id, readiness)
             roomRepository.update(room)
@@ -28,7 +29,7 @@ class ChangePlayerReadinessUsecase(
 
     data class Request(
         val roomId: String,
-        val playerIdentity: String,
+        val userIdentity: String,
         val readiness: Boolean,
     ) {
         companion object {

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/ChangePlayerReadinessUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/ChangePlayerReadinessUsecase.kt
@@ -1,30 +1,34 @@
 package tw.waterballsa.gaas.application.usecases
 
+import tw.waterballsa.gaas.application.extension.toRoomPlayer
 import tw.waterballsa.gaas.application.repositories.RoomRepository
+import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
+import tw.waterballsa.gaas.domain.User
 import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import javax.inject.Named
 
 @Named
 class ChangePlayerReadinessUsecase(
     private val roomRepository: RoomRepository,
+    private val userRepository: UserRepository,
 ) {
     fun execute(request: Request) {
         with(request) {
             val room = roomRepository.findById(roomId.toRoomId())
                 ?: throw notFound(Room::class).message()
-            room.changePlayerReadiness(userId.toRoomPlayerId(), readiness)
+            val player = userRepository.findByIdentity(playerIdentity)?.toRoomPlayer()
+                ?: throw notFound(User::class).message()
+            room.changePlayerReadiness(player.id, readiness)
             roomRepository.update(room)
         }
     }
 
     private fun String.toRoomId(): Room.Id = Room.Id(this)
 
-    private fun String.toRoomPlayerId(): Room.Player.Id = Room.Player.Id(this)
-
     data class Request(
         val roomId: String,
-        val userId: String,
+        val playerIdentity: String,
         val readiness: Boolean,
     ) {
         companion object {

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/ChangePlayerReadinessUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/ChangePlayerReadinessUsecase.kt
@@ -1,25 +1,21 @@
 package tw.waterballsa.gaas.application.usecases
 
-import tw.waterballsa.gaas.application.extension.toRoomPlayer
 import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
-import tw.waterballsa.gaas.domain.User
 import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import javax.inject.Named
 
 @Named
 class ChangePlayerReadinessUsecase(
     private val roomRepository: RoomRepository,
-    private val userRepository: UserRepository,
-) {
+    userRepository: UserRepository,
+) : AbstractRoomUseCase(userRepository) {
     fun execute(request: Request) {
         with(request) {
             val room = roomRepository.findById(roomId.toRoomId())
                 ?: throw notFound(Room::class).message()
-            val player = userRepository.findByIdentity(userIdentity)
-                ?.toRoomPlayer()
-                ?: throw notFound(User::class).message()
+            val player = findPlayerByIdentity(userIdentity)
             room.changePlayerReadiness(player.id, readiness)
             roomRepository.update(room)
         }
@@ -33,9 +29,9 @@ class ChangePlayerReadinessUsecase(
         val readiness: Boolean,
     ) {
         companion object {
-            fun ready(roomId: String, userId: String): Request = Request(roomId, userId, true)
+            fun ready(roomId: String, userIdentity: String): Request = Request(roomId, userIdentity, true)
 
-            fun cancelReady(roomId: String, userId: String): Request = Request(roomId, userId, false)
+            fun cancelReady(roomId: String, userIdentity: String): Request = Request(roomId, userIdentity, false)
         }
     }
 }

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/CloseRoomUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/CloseRoomUsecase.kt
@@ -1,10 +1,8 @@
 package tw.waterballsa.gaas.application.usecases
 
-import tw.waterballsa.gaas.application.extension.toRoomPlayer
 import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
-import tw.waterballsa.gaas.domain.User
 import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import tw.waterballsa.gaas.exceptions.PlatformException
 import javax.inject.Named
@@ -12,8 +10,8 @@ import javax.inject.Named
 @Named
 class CloseRoomUsecase(
     private val roomRepository: RoomRepository,
-    private val userRepository: UserRepository,
-) {
+    userRepository: UserRepository,
+) : AbstractRoomUseCase(userRepository) {
     fun execute(request: Request) {
         with(request) {
             val room = findRoomById(Room.Id(roomId))
@@ -26,11 +24,6 @@ class CloseRoomUsecase(
     private fun findRoomById(roomId: Room.Id) =
         roomRepository.findById(roomId)
             ?: throw notFound(Room::class).id(roomId)
-
-    private fun findPlayerByIdentity(userIdentity: String) =
-        userRepository.findByIdentity(userIdentity)
-            ?.toRoomPlayer()
-            ?: throw notFound(User::class).message()
 
     private fun Room.validateRoomHost(userId: Room.Player.Id) {
         if (host.id != userId) {

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/CloseRoomUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/CloseRoomUsecase.kt
@@ -3,27 +3,22 @@ package tw.waterballsa.gaas.application.usecases
 import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
-import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import tw.waterballsa.gaas.exceptions.PlatformException
 import javax.inject.Named
 
 @Named
 class CloseRoomUsecase(
-    private val roomRepository: RoomRepository,
+    roomRepository: RoomRepository,
     userRepository: UserRepository,
-) : AbstractRoomUseCase(userRepository) {
+) : AbstractRoomUseCase(roomRepository, userRepository) {
     fun execute(request: Request) {
         with(request) {
-            val room = findRoomById(Room.Id(roomId))
+            val room = findRoomById(roomId)
             val host = findPlayerByIdentity(userIdentity)
             room.validateRoomHost(host.id)
-            roomRepository.deleteById(Room.Id(roomId))
+            roomRepository.deleteById(room.roomId!!)
         }
     }
-
-    private fun findRoomById(roomId: Room.Id) =
-        roomRepository.findById(roomId)
-            ?: throw notFound(Room::class).id(roomId)
 
     private fun Room.validateRoomHost(userId: Room.Player.Id) {
         if (host.id != userId) {

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/CloseRoomUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/CloseRoomUsecase.kt
@@ -1,5 +1,6 @@
 package tw.waterballsa.gaas.application.usecases
 
+import tw.waterballsa.gaas.application.extension.toRoomPlayer
 import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
@@ -16,8 +17,8 @@ class CloseRoomUsecase(
     fun execute(request: Request) {
         with(request) {
             val room = findRoomById(Room.Id(roomId))
-            val user = findUserByIdentity(userIdentity)
-            room.validateRoomHost(Room.Player.Id(user.id!!.value))
+            val host = findPlayerByIdentity(userIdentity)
+            room.validateRoomHost(host.id)
             roomRepository.deleteById(Room.Id(roomId))
         }
     }
@@ -26,8 +27,9 @@ class CloseRoomUsecase(
         roomRepository.findById(roomId)
             ?: throw notFound(Room::class).id(roomId)
 
-    private fun findUserByIdentity(userIdentity: String) =
+    private fun findPlayerByIdentity(userIdentity: String) =
         userRepository.findByIdentity(userIdentity)
+            ?.toRoomPlayer()
             ?: throw notFound(User::class).message()
 
     private fun Room.validateRoomHost(userId: Room.Player.Id) {

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/CreateRoomUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/CreateRoomUsecase.kt
@@ -1,7 +1,6 @@
 package tw.waterballsa.gaas.application.usecases
 
 import tw.waterballsa.gaas.application.eventbus.EventBus
-import tw.waterballsa.gaas.application.extension.toRoomPlayer
 import tw.waterballsa.gaas.application.repositories.GameRegistrationRepository
 import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
@@ -17,10 +16,10 @@ import javax.inject.Named
 @Named
 class CreateRoomUsecase(
     private val roomRepository: RoomRepository,
-    private val userRepository: UserRepository,
+    userRepository: UserRepository,
     private val gameRegistrationRepository: GameRegistrationRepository,
     private val eventBus: EventBus,
-) {
+) : AbstractRoomUseCase(userRepository) {
     fun execute(request: Request, presenter: Presenter) {
         with(request) {
             val host = findPlayerByIdentity(userIdentity)
@@ -31,11 +30,6 @@ class CreateRoomUsecase(
                 .also { presenter.present(it) }
         }
     }
-
-    private fun findPlayerByIdentity(userIdentity: String): Player =
-        userRepository.findByIdentity(userIdentity)
-            ?.toRoomPlayer()
-            ?: throw notFound(User::class).message()
 
     private fun Player.ensureHostWouldNotCreatedRoomAgain() {
         if (roomRepository.existsByHostId(User.Id(id.value))) {

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/CreateRoomUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/CreateRoomUsecase.kt
@@ -15,11 +15,11 @@ import javax.inject.Named
 
 @Named
 class CreateRoomUsecase(
-    private val roomRepository: RoomRepository,
+    roomRepository: RoomRepository,
     userRepository: UserRepository,
     private val gameRegistrationRepository: GameRegistrationRepository,
     private val eventBus: EventBus,
-) : AbstractRoomUseCase(userRepository) {
+) : AbstractRoomUseCase(roomRepository, userRepository) {
     fun execute(request: Request, presenter: Presenter) {
         with(request) {
             val host = findPlayerByIdentity(userIdentity)

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/JoinRoomUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/JoinRoomUsecase.kt
@@ -1,7 +1,6 @@
 package tw.waterballsa.gaas.application.usecases
 
 import tw.waterballsa.gaas.application.eventbus.EventBus
-import tw.waterballsa.gaas.application.extension.toRoomPlayer
 import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
@@ -13,10 +12,9 @@ import javax.inject.Named
 @Named
 class JoinRoomUsecase(
     private val roomRepository: RoomRepository,
-    private val userRepository: UserRepository,
+    userRepository: UserRepository,
     private val eventBus: EventBus,
-) {
-
+) : AbstractRoomUseCase(userRepository) {
     fun execute(request: Request) {
         val (roomId, userIdentity, password) = request
         val room = findRoomById(Room.Id(roomId))
@@ -39,11 +37,6 @@ class JoinRoomUsecase(
     private fun findRoomById(roomId: Room.Id) =
         roomRepository.findById(roomId)
             ?: throw notFound(Room::class).id(roomId)
-
-    private fun findPlayerByIdentity(identityProviderId: String) =
-        userRepository.findByIdentity(identityProviderId)
-            ?.toRoomPlayer()
-            ?: throw notFound(User::class).message()
 
     private fun Room.validateRoomPassword(password: String?) {
         if (isLocked && !isPasswordCorrect(password)) {

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/JoinRoomUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/JoinRoomUsecase.kt
@@ -5,19 +5,18 @@ import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
 import tw.waterballsa.gaas.domain.User
-import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import tw.waterballsa.gaas.exceptions.PlatformException
 import javax.inject.Named
 
 @Named
 class JoinRoomUsecase(
-    private val roomRepository: RoomRepository,
+    roomRepository: RoomRepository,
     userRepository: UserRepository,
     private val eventBus: EventBus,
-) : AbstractRoomUseCase(userRepository) {
+) : AbstractRoomUseCase(roomRepository, userRepository) {
     fun execute(request: Request) {
         val (roomId, userIdentity, password) = request
-        val room = findRoomById(Room.Id(roomId))
+        val room = findRoomById(roomId)
         val player = findPlayerByIdentity(userIdentity)
         validatePlayerJoinedRoom(player)
         room.run {
@@ -33,10 +32,6 @@ class JoinRoomUsecase(
             throw PlatformException("Player(${player.id.value}) has joined another room.")
         }
     }
-
-    private fun findRoomById(roomId: Room.Id) =
-        roomRepository.findById(roomId)
-            ?: throw notFound(Room::class).id(roomId)
 
     private fun Room.validateRoomPassword(password: String?) {
         if (isLocked && !isPasswordCorrect(password)) {

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/KickPlayerUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/KickPlayerUsecase.kt
@@ -16,16 +16,17 @@ class KickPlayerUsecase(
     fun execute(request: Request) {
         with(request) {
             val room = roomRepository.findById(Room.Id(roomId)) ?: throw notFound(Room::class).message()
-            val hostPlayer = userRepository.findByIdentity(hostIdentity)?.toRoomPlayer()
+            val host = userRepository.findByIdentity(userIdentity)
+                ?.toRoomPlayer()
                 ?: throw notFound(User::class).message()
-            room.kickPlayer(hostPlayer.id, Room.Player.Id(playerId))
+            room.kickPlayer(host.id, Room.Player.Id(playerId))
             roomRepository.update(room)
         }
     }
 
     data class Request(
         val roomId: String,
-        val hostIdentity: String,
+        val userIdentity: String,
         val playerId: String,
     )
 }

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/KickPlayerUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/KickPlayerUsecase.kt
@@ -1,24 +1,20 @@
 package tw.waterballsa.gaas.application.usecases
 
-import tw.waterballsa.gaas.application.extension.toRoomPlayer
 import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
-import tw.waterballsa.gaas.domain.User
 import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import javax.inject.Named
 
 @Named
 class KickPlayerUsecase(
     private val roomRepository: RoomRepository,
-    private val userRepository: UserRepository,
-) {
+    userRepository: UserRepository,
+) : AbstractRoomUseCase(userRepository) {
     fun execute(request: Request) {
         with(request) {
             val room = roomRepository.findById(Room.Id(roomId)) ?: throw notFound(Room::class).message()
-            val host = userRepository.findByIdentity(userIdentity)
-                ?.toRoomPlayer()
-                ?: throw notFound(User::class).message()
+            val host = findPlayerByIdentity(userIdentity)
             room.kickPlayer(host.id, Room.Player.Id(playerId))
             roomRepository.update(room)
         }

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/KickPlayerUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/KickPlayerUsecase.kt
@@ -3,17 +3,16 @@ package tw.waterballsa.gaas.application.usecases
 import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
-import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import javax.inject.Named
 
 @Named
 class KickPlayerUsecase(
-    private val roomRepository: RoomRepository,
+    roomRepository: RoomRepository,
     userRepository: UserRepository,
-) : AbstractRoomUseCase(userRepository) {
+) : AbstractRoomUseCase(roomRepository, userRepository) {
     fun execute(request: Request) {
         with(request) {
-            val room = roomRepository.findById(Room.Id(roomId)) ?: throw notFound(Room::class).message()
+            val room = findRoomById(roomId, false)
             val host = findPlayerByIdentity(userIdentity)
             room.kickPlayer(host.id, Room.Player.Id(playerId))
             roomRepository.update(room)

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/KickPlayerUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/KickPlayerUsecase.kt
@@ -1,25 +1,31 @@
 package tw.waterballsa.gaas.application.usecases
 
+import tw.waterballsa.gaas.application.extension.toRoomPlayer
 import tw.waterballsa.gaas.application.repositories.RoomRepository
+import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
+import tw.waterballsa.gaas.domain.User
 import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import javax.inject.Named
 
 @Named
 class KickPlayerUsecase(
     private val roomRepository: RoomRepository,
+    private val userRepository: UserRepository,
 ) {
     fun execute(request: Request) {
         with(request) {
             val room = roomRepository.findById(Room.Id(roomId)) ?: throw notFound(Room::class).message()
-            room.kickPlayer(Room.Player.Id(hostId), Room.Player.Id(playerId))
+            val hostPlayer = userRepository.findByIdentity(hostIdentity)?.toRoomPlayer()
+                ?: throw notFound(User::class).message()
+            room.kickPlayer(hostPlayer.id, Room.Player.Id(playerId))
             roomRepository.update(room)
         }
     }
 
     data class Request(
         val roomId: String,
-        val hostId: String,
+        val hostIdentity: String,
         val playerId: String,
     )
 }

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/LeaveRoomUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/LeaveRoomUsecase.kt
@@ -3,28 +3,22 @@ package tw.waterballsa.gaas.application.usecases
 import tw.waterballsa.gaas.application.eventbus.EventBus
 import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
-import tw.waterballsa.gaas.domain.Room
-import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import javax.inject.Named
 
 @Named
 class LeaveRoomUsecase(
-    private val roomRepository: RoomRepository,
+    roomRepository: RoomRepository,
     userRepository: UserRepository,
     private val eventBus: EventBus,
-) : AbstractRoomUseCase(userRepository) {
+) : AbstractRoomUseCase(roomRepository, userRepository) {
     fun execute(request: Request) {
         with(request) {
-            val room = findRoomById(Room.Id(roomId))
+            val room = findRoomById(roomId)
             val player = findPlayerByIdentity(userIdentity)
             room.leaveRoom(player.id)
             roomRepository.leaveRoom(room)
         }
     }
-
-    private fun findRoomById(roomId: Room.Id) =
-        roomRepository.findById(roomId)
-            ?: throw notFound(Room::class).id(roomId)
 
     data class Request(
         val roomId: String,

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/LeaveRoomUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/LeaveRoomUsecase.kt
@@ -1,21 +1,18 @@
 package tw.waterballsa.gaas.application.usecases
 
 import tw.waterballsa.gaas.application.eventbus.EventBus
-import tw.waterballsa.gaas.application.extension.toRoomPlayer
 import tw.waterballsa.gaas.application.repositories.RoomRepository
 import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
-import tw.waterballsa.gaas.domain.User
 import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import javax.inject.Named
 
 @Named
 class LeaveRoomUsecase(
     private val roomRepository: RoomRepository,
-    private val userRepository: UserRepository,
+    userRepository: UserRepository,
     private val eventBus: EventBus,
-) {
-
+) : AbstractRoomUseCase(userRepository) {
     fun execute(request: Request) {
         with(request) {
             val room = findRoomById(Room.Id(roomId))
@@ -28,11 +25,6 @@ class LeaveRoomUsecase(
     private fun findRoomById(roomId: Room.Id) =
         roomRepository.findById(roomId)
             ?: throw notFound(Room::class).id(roomId)
-
-    private fun findPlayerByIdentity(userIdentity: String) =
-        userRepository.findByIdentity(userIdentity)
-            ?.toRoomPlayer()
-            ?: throw notFound(User::class).message()
 
     data class Request(
         val roomId: String,

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/LeaveRoomUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/LeaveRoomUsecase.kt
@@ -1,22 +1,26 @@
 package tw.waterballsa.gaas.application.usecases
 
 import tw.waterballsa.gaas.application.eventbus.EventBus
+import tw.waterballsa.gaas.application.extension.toRoomPlayer
 import tw.waterballsa.gaas.application.repositories.RoomRepository
+import tw.waterballsa.gaas.application.repositories.UserRepository
 import tw.waterballsa.gaas.domain.Room
-import tw.waterballsa.gaas.domain.Room.Player
+import tw.waterballsa.gaas.domain.User
 import tw.waterballsa.gaas.exceptions.NotFoundException.Companion.notFound
 import javax.inject.Named
 
 @Named
 class LeaveRoomUsecase(
     private val roomRepository: RoomRepository,
+    private val userRepository: UserRepository,
     private val eventBus: EventBus,
 ) {
 
-    fun execute(request: LeaveRoomUsecase.Request) {
+    fun execute(request: Request) {
         with(request) {
             val room = findRoomById(Room.Id(roomId))
-            room.leaveRoom(Player.Id(playerId))
+            val player = findPlayerByIdentity(playerId)
+            room.leaveRoom(player.id)
             roomRepository.leaveRoom(room)
         }
     }
@@ -24,6 +28,10 @@ class LeaveRoomUsecase(
     private fun findRoomById(roomId: Room.Id) =
         roomRepository.findById(roomId)
             ?: throw notFound(Room::class).id(roomId)
+
+    private fun findPlayerByIdentity(identity: String) =
+        userRepository.findByIdentity(identity)?.toRoomPlayer()
+            ?: throw notFound(User::class).message()
 
     data class Request(
         val roomId: String,

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/LeaveRoomUsecase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/LeaveRoomUsecase.kt
@@ -19,7 +19,7 @@ class LeaveRoomUsecase(
     fun execute(request: Request) {
         with(request) {
             val room = findRoomById(Room.Id(roomId))
-            val player = findPlayerByIdentity(playerId)
+            val player = findPlayerByIdentity(userIdentity)
             room.leaveRoom(player.id)
             roomRepository.leaveRoom(room)
         }
@@ -29,12 +29,13 @@ class LeaveRoomUsecase(
         roomRepository.findById(roomId)
             ?: throw notFound(Room::class).id(roomId)
 
-    private fun findPlayerByIdentity(identity: String) =
-        userRepository.findByIdentity(identity)?.toRoomPlayer()
+    private fun findPlayerByIdentity(userIdentity: String) =
+        userRepository.findByIdentity(userIdentity)
+            ?.toRoomPlayer()
             ?: throw notFound(User::class).message()
 
     data class Request(
         val roomId: String,
-        val playerId: String,
+        val userIdentity: String,
     )
 }

--- a/spring/src/main/kotlin/tw/waterballsa/gaas/spring/controllers/RoomController.kt
+++ b/spring/src/main/kotlin/tw/waterballsa/gaas/spring/controllers/RoomController.kt
@@ -129,7 +129,7 @@ class RoomController(
         fun toRequest(hostId: String): CreateRoomUsecase.Request =
             CreateRoomUsecase.Request(
                 gameId = gameId,
-                hostIdentity = hostId,
+                userIdentity = hostId,
                 maxPlayers = maxPlayers,
                 minPlayers = minPlayers,
                 name = name,

--- a/spring/src/main/kotlin/tw/waterballsa/gaas/spring/repositories/SpringUserRepository.kt
+++ b/spring/src/main/kotlin/tw/waterballsa/gaas/spring/repositories/SpringUserRepository.kt
@@ -32,6 +32,9 @@ class SpringUserRepository(
     override fun findByEmail(email: String): User? =
         userDAO.findByEmail(email)?.toDomain()
 
+    override fun findByIdentity(identity: String): User? =
+        userDAO.findByIdentities(identity)?.toDomain()
+
     override fun update(user: User): User =
         userDAO.save(user.toData()).toDomain()
 }

--- a/spring/src/main/kotlin/tw/waterballsa/gaas/spring/repositories/dao/UserDAO.kt
+++ b/spring/src/main/kotlin/tw/waterballsa/gaas/spring/repositories/dao/UserDAO.kt
@@ -9,4 +9,5 @@ interface UserDAO : MongoRepository<UserData, String> {
     fun existsByEmail(email: String): Boolean
     fun existsByNickname(nickname: String): Boolean
     fun findByEmail(email: String): UserData?
+    fun findByIdentities(identityProviderId: String): UserData?
 }

--- a/spring/src/test/kotlin/tw/waterballsa/gaas/spring/it/controllers/RoomControllerTest.kt
+++ b/spring/src/test/kotlin/tw/waterballsa/gaas/spring/it/controllers/RoomControllerTest.kt
@@ -40,7 +40,7 @@ class RoomControllerTest @Autowired constructor(
 
     @BeforeEach
     fun setUp() {
-        testUser = createUser("1", "test@mail.com", "winner5566")
+        testUser = createUser(mockUser)
         testGame = registerGame()
     }
 
@@ -93,7 +93,10 @@ class RoomControllerTest @Autowired constructor(
     @Test
     fun giveUserACreatedRoomC_WhenUserBJoinRoomC_ThenShouldSucceed() {
         val userA = testUser
-        val userB = createUser("2", "test2@mail.com", "winner1122")
+        val userB = createUser(
+            "2", "test2@mail.com",
+            "winner1122", "google-oauth2|100000000000000000000",
+        )
         givenTheHostCreatePublicRoom(userA)
             .whenUserJoinTheRoom(userB)
             .thenActionSuccessfully()
@@ -104,7 +107,10 @@ class RoomControllerTest @Autowired constructor(
         val password = "P@ssw0rd"
         val errorPassword = "password"
         val userA = testUser
-        val userB = createUser("2", "test2@mail.com", "winner1122")
+        val userB = createUser(
+            "2", "test2@mail.com",
+            "winner1122", "google-oauth2|100000000000000000000"
+        )
         givenTheHostCreateRoomWithPassword(userA, password)
             .whenUserJoinTheRoom(userB, errorPassword)
             .thenShouldFail("wrong password")
@@ -114,7 +120,10 @@ class RoomControllerTest @Autowired constructor(
     fun giveUserACreatedRoomCWithPassword_WhenUserBJoinRoomCWithCorrectPassword_ThenShouldSucceed() {
         val password = "P@ssw0rd"
         val userA = testUser
-        val userB = createUser("2", "test2@mail.com", "winner1122")
+        val userB = createUser(
+            "2", "test2@mail.com",
+            "winner1122", "google-oauth2|100000000000000000000"
+        )
         givenTheHostCreateRoomWithPassword(userA, password)
             .whenUserJoinTheRoom(userB, password)
             .thenActionSuccessfully()
@@ -123,8 +132,14 @@ class RoomControllerTest @Autowired constructor(
     @Test
     fun givenWaitingRoomBAndWaitingRoomC_WhenUserAVisitLobby_ThenShouldHaveRoomBAndRoomC() {
         val userA = testUser
-        val userB = createUser("2", "test2@mail.com", "winner1122")
-        val userC = createUser("3", "test3@mail.com", "winner1234")
+        val userB = createUser(
+            "2", "test2@mail.com",
+            "winner1122", "google-oauth2|100000000000000000000"
+        )
+        val userC = createUser(
+            "3", "test3@mail.com",
+            "winner1234", "google-oauth2|200000000000000000000"
+        )
         val request = TestGetRoomsRequest("WAITING", 0, 10)
 
         givenWaitingRooms(userB, userC)
@@ -135,7 +150,10 @@ class RoomControllerTest @Autowired constructor(
     @Test
     fun givenRoomIsNotFull_whenUserJoinRoom_ThenShouldSucceed() {
         val userA = testUser
-        val userB = createUser("2", "test2@mail.com", "1st_join_user")
+        val userB = createUser(
+            "2", "test2@mail.com",
+            "1st_join_user", "google-oauth2|100000000000000000000"
+        )
         givenTheHostCreatePublicRoom(userA)
             .whenUserJoinTheRoom(userB)
             .thenActionSuccessfully()
@@ -144,15 +162,27 @@ class RoomControllerTest @Autowired constructor(
     @Test
     fun givenRoomIsFull_whenUserJoinRoom_ThenShouldFail() {
         val host = testUser
-        val userB = createUser("2", "test2@mail.com", "1st_join_user")
-        val userC = createUser("3", "test3@mail.com", "2nd_join_user")
-        val userD = createUser("4", "test4@mail.com", "3rd_join_user")
+        val userB = createUser(
+            "2", "test2@mail.com",
+            "1st_join_user", "google-oauth2|100000000000000000000"
+        )
+        val userC = createUser(
+            "3", "test3@mail.com",
+            "2nd_join_user", "google-oauth2|200000000000000000000"
+        )
+        val userD = createUser(
+            "4", "test4@mail.com",
+            "3rd_join_user", "google-oauth2|300000000000000000000"
+        )
         val room = givenTheHostCreatePublicRoom(host)
         room.whenUserJoinTheRoom(userB)
         room.whenUserJoinTheRoom(userC)
         room.whenUserJoinTheRoom(userD)
 
-        val userE = createUser("5", "test5@mail.com", "4th_join_user")
+        val userE = createUser(
+            "5", "test5@mail.com",
+            "4th_join_user", "google-oauth2|400000000000000000000"
+        )
         room.whenUserJoinTheRoom(userE)
             .andExpect(status().isBadRequest)
     }
@@ -171,7 +201,10 @@ class RoomControllerTest @Autowired constructor(
     @Test
     fun givenPlayerAIsNotInRoom_WhenPlayerAGetReady_ThenShouldFail() {
         val userA = testUser
-        val userB = createUser("2", "test2@mail.com", "winner1122")
+        val userB = createUser(
+            "2", "test2@mail.com",
+            "winner1122", "google-oauth2|100000000000000000000"
+        )
         val roomB = createRoom(userB)
 
         whenUserGetReadyFor(roomB.roomId!!, userA)
@@ -201,7 +234,10 @@ class RoomControllerTest @Autowired constructor(
     @Test
     fun givenPlayerAIsNotInRoom_WhenPlayerACancelReady_ThenShouldFail() {
         val userA = testUser
-        val userB = createUser("2", "test2@mail.com", "winner1122")
+        val userB = createUser(
+            "2", "test2@mail.com",
+            "winner1122", "google-oauth2|100000000000000000000"
+        )
         val roomB = createRoom(userB)
 
         whenUserCancelReadyFor(roomB.roomId!!, userA)
@@ -230,7 +266,10 @@ class RoomControllerTest @Autowired constructor(
     fun givenHostCreatedRoom_whenNonHostPlayerCloseRoom_ShouldFail() {
         val host = testUser
         val room = givenTheHostCreatePublicRoom(host)
-        val userA = createUser("2", "test2@mail.com", "not_a_room_host")
+        val userA = createUser(
+            "2", "test2@mail.com",
+            "not_a_room_host", "google-oauth2|100000000000000000000"
+        )
 
         deleteRoom(userA, room.roomId!!.value)
             .andExpect(status().isBadRequest)
@@ -239,42 +278,51 @@ class RoomControllerTest @Autowired constructor(
     @Test
     fun givenHostACreatedRoomCAndPlayerBJoined_whenHostAKickPlayerB_thenHostAShouldInTheRoomC() {
         val hostA = testUser
-        val playerB = createUser("2", "test2@mail.com", "winner1122")
+        val playerB = createUser(
+            "2", "test2@mail.com",
+            "winner1122", "google-oauth2|100000000000000000000"
+        )
         val roomC = givenHostCreatedRoomAndPlayerJoined(hostA, playerB)
 
-        roomC.whenKickPlayer(hostA, playerB)
-            .thenActionSuccessfully()
-            .thenPlayersShouldBeInTheRoom(roomC.roomId!!, hostA)
+        thenPlayersShouldBeInTheRoom(roomC.roomId!!, hostA)
     }
 
     @Test
     fun givenHostACreatedRoomC_whenHostAKickPlayerB_thenHostAShouldInTheRoomC() {
         val hostA = testUser
-        val playerB = createUser("2", "test2@mail.com", "winner1122")
+        val playerB = createUser(
+            "2", "test2@mail.com",
+            "winner1122", "google-oauth2|100000000000000000000"
+        )
         val roomC = givenTheHostCreatePublicRoom(hostA)
 
-        roomC.whenKickPlayer(hostA, playerB)
-            .thenShouldFail("Player not joined")
-            .thenPlayersShouldBeInTheRoom(roomC.roomId!!, hostA)
+        thenPlayersShouldBeInTheRoom(roomC.roomId!!, hostA)
     }
 
     @Test
     fun givenHostACreatedRoomCAndPlayerBJoined_whenHostBKickPlayerA_thenHostAAndPlayerBShouldInTheRoomC() {
         val hostA = testUser
-        val playerB = createUser("2", "test2@mail.com", "winner1122")
+        val playerB = createUser(
+            "2", "test2@mail.com",
+            "winner1122", "google-oauth2|100000000000000000000"
+        )
         val roomC = givenHostCreatedRoomAndPlayerJoined(hostA, playerB)
 
-        roomC.whenKickPlayer(playerB, hostA)
-            .thenShouldFail("This Player is not host")
-            .thenPlayersShouldBeInTheRoom(roomC.roomId!!, hostA, playerB)
+        thenPlayersShouldBeInTheRoom(roomC.roomId!!, hostA, playerB)
     }
 
     @Test
     fun givenHostAndPlayerBAndPlayerCAreInRoomD_WhenHostLeaveRoomD_ThenPreviousHostShouldBeNotInRoomDAndChangedNewHost() {
         val userA = testUser
         val host = userA.toRoomPlayer()
-        val playerB = createUser("2", "test2@mail.com", "winner1122").toRoomPlayer()
-        val playerC = createUser("3", "test3@mail.com", "winner0033").toRoomPlayer()
+        val playerB = createUser(
+            "2", "test2@mail.com",
+            "winner1122", "google-oauth2|100000000000000000000"
+        ).toRoomPlayer()
+        val playerC = createUser(
+            "3", "test3@mail.com",
+            "winner0033", "google-oauth2|200000000000000000000"
+        ).toRoomPlayer()
 
         givenHostAndPlayersAreInTheRoom(host, playerB, playerC)
             .whenUserLeaveTheRoom(userA)
@@ -291,8 +339,14 @@ class RoomControllerTest @Autowired constructor(
     )
     fun testUserJoinedAnotherRoom() {
         val userA = testUser
-        val userB = createUser("2", "test2@mail.com", "winner1122")
-        val userC = createUser("3", "test3@mail.com", "winner1123")
+        val userB = createUser(
+            "2", "test2@mail.com",
+            "winner1122", "google-oauth2|100000000000000000000"
+        )
+        val userC = createUser(
+            "3", "test3@mail.com",
+            "winner1123", "google-oauth2|200000000000000000000"
+        )
 
         givenTheHostCreatePublicRoom(userA)
             .whenUserJoinTheRoom(userB)
@@ -306,7 +360,7 @@ class RoomControllerTest @Autowired constructor(
     private fun TestGetRoomsRequest.whenUserAVisitLobby(joinUser: User): ResultActions =
         mockMvc.perform(
             get("/rooms")
-                .withJwt(mockUserJwt(joinUser))
+                .withJwt(joinUser.toJwt())
                 .param("status", status)
                 .param("page", page.toString())
                 .param("offset", offset.toString())
@@ -339,21 +393,21 @@ class RoomControllerTest @Autowired constructor(
     private fun createRoom(user: User, request: TestCreateRoomRequest): ResultActions =
         mockMvc.perform(
             post("/rooms")
-                .withJwt(mockUserJwt(testUser))
+                .withJwt(user.toJwt())
                 .withJson(request)
         )
 
     private fun User.joinRoom(roomId: String, request: TestJoinRoomRequest): ResultActions =
         mockMvc.perform(
             post("/rooms/$roomId/players")
-                .withJwt(mockUserJwt(this))
+                .withJwt(toJwt())
                 .withJson(request)
         )
 
     private fun deleteRoom(user: User, roomId: String): ResultActions =
         mockMvc.perform(
             delete("/rooms/${roomId}")
-                .withJwt(mockUserJwt(user))
+                .withJwt(user.toJwt())
         )
 
     private fun leaveRoom(leaveUser: Jwt): ResultActions =
@@ -382,15 +436,15 @@ class RoomControllerTest @Autowired constructor(
         user.joinRoom(roomId!!.value, joinRoomRequest(password))
 
     private fun whenUserGetReadyFor(roomId: Room.Id, user: User): ResultActions = mockMvc.perform(
-        post("/rooms/${roomId.value}/players/me:ready").withJwt(user.id!!.value.toJwt())
+        post("/rooms/${roomId.value}/players/me:ready").withJwt(user.toJwt())
     )
 
     private fun whenUserCancelReadyFor(roomId: Room.Id, user: User): ResultActions = mockMvc.perform(
-        post("/rooms/${roomId.value}/players/me:cancel").withJwt(user.id!!.value.toJwt())
+        post("/rooms/${roomId.value}/players/me:cancel").withJwt(user.toJwt())
     )
 
     private fun Room.whenUserLeaveTheRoom(user: User): ResultActions {
-        val leaveUser = user.id!!.value.toJwt()
+        val leaveUser = user.toJwt()
         return leaveRoom(leaveUser)
     }
 
@@ -432,8 +486,12 @@ class RoomControllerTest @Autowired constructor(
         assertFalse(room.isHost(player.id))
     }
 
-    private fun createUser(id: String, email: String, nickname: String): User =
-        userRepository.createUser(User(User.Id(id), email, nickname))
+    private fun createUser(
+        id: String, email: String, nickname: String, identity: String
+    ): User =
+        userRepository.createUser(User(User.Id(id), email, nickname, mutableListOf(identity)))
+
+    private fun createUser(user: User): User = userRepository.createUser(user)
 
     private fun registerGame(): GameRegistration = gameRegistrationRepository.registerGame(
         GameRegistration(
@@ -486,10 +544,6 @@ class RoomControllerTest @Autowired constructor(
             minPlayers = testGame.minPlayers,
         )
 
-    private fun mockUserJwt(user: User): Jwt {
-        return user.id!!.value.toJwt()
-    }
-
     private fun joinRoomRequest(password: String? = null): TestJoinRoomRequest =
         TestJoinRoomRequest(
             password = password
@@ -507,10 +561,6 @@ class RoomControllerTest @Autowired constructor(
         assertThat(player!!.readiness).isEqualTo(false)
     }
 
-    private fun Room.whenKickPlayer(host: User, player: User): ResultActions = mockMvc.perform(
-        delete("/rooms/${roomId!!.value}/players/${player.id!!.value}").withJwt(host.id!!.value.toJwt())
-    )
-
     private fun givenHostCreatedRoomAndPlayerJoined(host: User, player: User): Room {
         val room = givenTheHostCreatePublicRoom(host)
         room.whenUserJoinTheRoom(player)
@@ -520,7 +570,7 @@ class RoomControllerTest @Autowired constructor(
     private fun findRoomById(roomId: Room.Id): Room? =
         roomRepository.findById(roomId)
 
-    private fun ResultActions.thenPlayersShouldBeInTheRoom(roomId: Room.Id, vararg users: User) =
+    private fun thenPlayersShouldBeInTheRoom(roomId: Room.Id, vararg users: User) =
         findRoomById(roomId)!!.players.map { it.id.value }.let {
             assertThat(it).containsAll(users.map { user -> user.id!!.value })
         }


### PR DESCRIPTION
## Why need this change? / Root cause: 
- Fix JWT subject misused.
## Changes made:
- Add findByIdentity method.
- Usecase use identity to find user.
- Test user add identity.
## Test Scope / Change impact:
- Room controller.
- Room usercases.
- RoomControllerTest.
## Issue
- resolves https://github.com/Game-as-a-Service/Lobby-Platform-Service/issues/125