### PR TITLE
fix: user usecase use identity

### DIFF
--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/GetUserUseCase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/GetUserUseCase.kt
@@ -11,13 +11,13 @@ class GetUserUseCase(
 ) {
     fun execute(request: Request, presenter: Presenter) {
         with(request) {
-            val user = userRepository.findByEmail(email)
-                ?: throw notFound(User::class).identifyBy("email", email)
+            val user = userRepository.findByIdentity(userIdentity)
+                ?: throw notFound(User::class).identifyBy("userIdentity", userIdentity)
             presenter.present(user)
         }
     }
 
-    class Request(val email: String)
+    class Request(val userIdentity: String)
 
     interface Presenter {
         fun present(user: User)

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/UpdateUserUseCase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/UpdateUserUseCase.kt
@@ -16,7 +16,7 @@ class UpdateUserUseCase(
     fun execute(request: Request, presenter: Presenter) {
         with(request) {
             validateNicknameDuplicated(nickname)
-            val user = findUserByEmail(email)
+            val user = findUserByIdentity(userIdentity)
             user.changeNickname(nickname)
             val updatedUser = userRepository.update(user)
 
@@ -32,11 +32,11 @@ class UpdateUserUseCase(
         }
     }
 
-    private fun findUserByEmail(email: String) =
-        userRepository.findByEmail(email)
-            ?: throw notFound(User::class).identifyBy("email", email)
+    private fun findUserByIdentity(userIdentity: String) =
+        userRepository.findByIdentity(userIdentity)
+            ?: throw notFound(User::class).identifyBy("userIdentity", userIdentity)
 
-    data class Request(val email: String, val nickname: String)
+    data class Request(val userIdentity: String, val nickname: String)
 }
 
 private fun User.toUserUpdatedEvent(): UserUpdatedEvent =

--- a/spring/src/main/kotlin/tw/waterballsa/gaas/spring/controllers/UserController.kt
+++ b/spring/src/main/kotlin/tw/waterballsa/gaas/spring/controllers/UserController.kt
@@ -29,7 +29,7 @@ class UserController(
         @AuthenticationPrincipal principal: Jwt,
         @RequestBody updateUserRequest: UpdateUserRequest,
     ): UpdateUserViewModel {
-        val request = updateUserRequest.toRequest(principal.email)
+        val request = updateUserRequest.toRequest(principal.subject)
         val presenter = UpdateUserPresenter()
         updateUserUseCase.execute(request, presenter)
         return presenter.viewModel
@@ -37,7 +37,7 @@ class UserController(
 }
 
 private fun Jwt.toRequest(): GetUserUseCase.Request =
-    GetUserUseCase.Request(email)
+    GetUserUseCase.Request(subject)
 
 data class UpdateUserRequest(val nickname: String) {
 

--- a/spring/src/test/kotlin/tw/waterballsa/gaas/spring/it/AbstractSpringBootTest.kt
+++ b/spring/src/test/kotlin/tw/waterballsa/gaas/spring/it/AbstractSpringBootTest.kt
@@ -29,15 +29,14 @@ abstract class AbstractSpringBootTest {
         mutableListOf("google-oauth2|102527320242660434908")
     )
 
-    protected final fun String.toJwt(): Jwt = generateJwt(this, mockUser.email)
+    protected final fun String.toJwt(): Jwt = generateJwt(this)
 
-    protected final fun User.toJwt(): Jwt = generateJwt(identities.first(), email)
+    protected final fun User.toJwt(): Jwt = generateJwt(identities.first())
 
-    private fun generateJwt(id: String, email: String): Jwt =
+    private fun generateJwt(id: String): Jwt =
         Jwt.withTokenValue("mock-token")
             .header("alg", "none")
             .subject(id)
-            .claim("email", email)
             .build()
 
     protected fun <T> ResultActions.getBody(type: Class<T>): T =


### PR DESCRIPTION
## Why need this change? / Root cause: 
- The jwt claim doesn't have an email.
## Changes made:
- Remove test jwt email claim.
- User user identity to find user.
- OAuth2Controller principal change to OidcUser.
## Test Scope / Change impact:
- OAuth2ControllerTest
- AbstractSpringBootTest
## Issue
- resolves https://github.com/Game-as-a-Service/Lobby-Platform-Service/issues/132