### PR TITLE
Add roomId parameter when starting a game

### DIFF
--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/client/GameService.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/client/GameService.kt
@@ -5,6 +5,7 @@ interface GameService {
 }
 
 data class StartGameRequest(
+    val roomId: String,
     val players: List<GamePlayer>,
 ) {
     data class GamePlayer(

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/StartGameUseCase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/StartGameUseCase.kt
@@ -64,8 +64,11 @@ class StartGameUseCase(
     }
 
     private fun Room.startGameByHost(jwtToken: String): StartedGameEvent {
+        if(roomId == null) {
+            throw PlatformException(GAME_START_FAILED, "Room Id is null")
+        }
         val gameServerHost = game.backEndUrl
-        val startGameRequest = StartGameRequest(players.map { it.toGamePlayer() })
+        val startGameRequest = StartGameRequest(roomId.toString(), players.map { it.toGamePlayer() })
         val startGameResponse = gameService.startGame(gameServerHost, jwtToken, startGameRequest)
 
         return StartedGameEvent(GAME_STARTED, Data(startGameResponse.url, roomId!!))

--- a/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/StartGameUseCase.kt
+++ b/application/src/main/kotlin/tw/waterballsa/gaas/application/usecases/StartGameUseCase.kt
@@ -68,7 +68,7 @@ class StartGameUseCase(
             throw PlatformException(GAME_START_FAILED, "Room Id is null")
         }
         val gameServerHost = game.backEndUrl
-        val startGameRequest = StartGameRequest(roomId.toString(), players.map { it.toGamePlayer() })
+        val startGameRequest = StartGameRequest(roomId!!.value, players.map { it.toGamePlayer() })
         val startGameResponse = gameService.startGame(gameServerHost, jwtToken, startGameRequest)
 
         return StartedGameEvent(GAME_STARTED, Data(startGameResponse.url, roomId!!))

--- a/spring/src/test/kotlin/tw/waterballsa/gaas/spring/it/controllers/RoomControllerTest.kt
+++ b/spring/src/test/kotlin/tw/waterballsa/gaas/spring/it/controllers/RoomControllerTest.kt
@@ -781,7 +781,7 @@ class RoomControllerTest @Autowired constructor(
         mockMvc.perform(
             post("/rooms/${room.roomId!!.value}:startGame")
                 .withJwt(toJwt())
-                .withJson(StartGameRequest(room.players.map { it.toGamePlayer() }))
+                .withJson(StartGameRequest(room.roomId!!.value,room.players.map { it.toGamePlayer() }))
         )
 
     private fun Player.toGamePlayer(): StartGameRequest.GamePlayer =


### PR DESCRIPTION
## Why need this change? / Root cause: 
當呼叫遊戲小組的 start game API，大平台需要給 RoomId，所以當遊戲結束時，遊戲小組可以呼叫相對應的 end game API

## Changes made:
- `application/client/GameService.kt`
- `application/usecases/StartGameUseCase.kt`

## Test Scope / Change impact:
- N/A

## Issue
- solve #200