### PR TITLE
feat: use forward headers

### DIFF
--- a/spring/src/main/resources/application.yaml
+++ b/spring/src/main/resources/application.yaml
@@ -38,4 +38,5 @@ springdoc:
     tags-sorter: alpha
 
 server:
+  use-forward-headers: true
   forward-headers-strategy: native


### PR DESCRIPTION
## Why need this change? / Root cause: 

- 後端吃不到 http scheme ，一直轉址錯誤。

## Changes made:
- add `use-forward-headers: true`

